### PR TITLE
fix: 修复 CPU 使用率与任务管理器不一致的问题

### DIFF
--- a/src/System/HardwareServices/HardwareValueProvider.cs
+++ b/src/System/HardwareServices/HardwareValueProvider.cs
@@ -248,11 +248,19 @@ namespace LiteMonitor.src.SystemServices
 
                         if (result == null)
                         {
-                            result = _componentProcessor.GetCpuLoad();
-                            if (result == null && _manualSensorCache.TryGetValue("CPU.Load", out var fallbackS))
+                            // [Fix] 优先使用 LHM 的 "Total" 聚合传感器（与任务管理器一致）
+                            // 然后才回退到各核心平均值计算
+                            if (_manualSensorCache.TryGetValue("CPU.Load", out var totalSensor) && totalSensor.Value.HasValue)
                             {
-                                result = fallbackS.Value;
+                                result = totalSensor.Value.Value;
                             }
+
+                            // 如果 Total 传感器不可用，才回退到核心平均值
+                            if (result == null)
+                            {
+                                result = _componentProcessor.GetCpuLoad();
+                            }
+
                             if (result == null) result = 0f;
                         }
                         break;

--- a/src/System/HardwareServices/PerformanceCounterManager.cs
+++ b/src/System/HardwareServices/PerformanceCounterManager.cs
@@ -61,9 +61,13 @@ namespace LiteMonitor.src.SystemServices
                     // 2. 创建计数器实例
                     // 注意：CategoryName 即使在中文系统通常也支持英文，为了兼容性优先用英文
                     
-                    // CPU 负载：使用 Processor Information 类别 (Win8+ 推荐)，兼容性更好
-                    _cpuLoadCounter = CreateCounter("Processor Information", "% Processor Time", "_Total");
-                    if (_cpuLoadCounter == null) 
+                    // CPU 负载：使用 Processor Information 类别 (Win8+ 推荐)
+                    // [Fix] 使用 "% Processor Utility" 而非 "% Processor Time"
+                    // 任务管理器在 Win8+ 显示的是 "Utility" (考虑睿频)，而非 "Time"
+                    _cpuLoadCounter = CreateCounter("Processor Information", "% Processor Utility", "_Total");
+                    if (_cpuLoadCounter == null)
+                        _cpuLoadCounter = CreateCounter("Processor Information", "% Processor Time", "_Total"); // 回退1
+                    if (_cpuLoadCounter == null)
                         _cpuLoadCounter = CreateCounter("Processor", "% Processor Time", "_Total"); // 旧系统回退
 
                     // CPU 频率：读取性能百分比 (Performance Limit)，需配合基准频率计算


### PR DESCRIPTION
- 将 CPU 负载计数器从 % Processor Time 改为 % Processor Utility
- 优化回退逻辑，优先使用 LHM 的 Total 聚合传感器

Windows 任务管理器在 Win8+ 使用 Processor Utility 计算方式，
该方式考虑了 CPU 睿频，比 Processor Time 更准确。