### PR TITLE
feat: Add PreferredGpu setting for multi-GPU systems (dGPU/iGPU selection)

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -220,6 +220,7 @@
 
     "HardwareSettings": "Source",
     "DiskSource": "Disk",
+    "GpuSource": "GPU",
     "NetworkSource": "Network",
     "Auto": "Auto",
     "UseWinPerCounters": "Use Sys Counters",

--- a/resources/lang/zh.json
+++ b/resources/lang/zh.json
@@ -220,6 +220,7 @@
 
     "HardwareSettings": "硬件与传感器设置",
     "DiskSource": "首选磁盘",
+    "GpuSource": "首选显卡",
     "NetworkSource": "首选网卡",
     "Auto": "自动模式",
     "UseWinPerCounters": "优先使用系统计数器",

--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -1,0 +1,24 @@
+param(
+  [string]$Runtime = "win-x64",
+  [string]$Configuration = "Release",
+  [string]$Version = "dev"
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
+  Write-Error "dotnet CLI not found. Please install .NET SDK 8+ and retry."
+}
+
+$outDir = Join-Path $PSScriptRoot "artifacts/$Runtime"
+$publishDir = Join-Path $outDir "publish"
+New-Item -ItemType Directory -Force -Path $publishDir | Out-Null
+
+dotnet publish "$PSScriptRoot/../LiteMonitor.csproj" -c $Configuration -r $Runtime --self-contained false -o $publishDir
+
+$zipName = "LiteMonitor_v$Version-$Runtime.zip"
+$zipPath = Join-Path $outDir $zipName
+if (Test-Path $zipPath) { Remove-Item $zipPath -Force }
+Compress-Archive -Path (Join-Path $publishDir '*') -DestinationPath $zipPath
+
+Write-Host "Package created: $zipPath"

--- a/src/Core/Settings.cs
+++ b/src/Core/Settings.cs
@@ -33,6 +33,7 @@ namespace LiteMonitor
         public string LastAutoNetwork { get; set; } = "";
         public string PreferredDisk { get; set; } = "";
         public string LastAutoDisk { get; set; } = "";
+        public string PreferredGpu { get; set; } = "";   // ★★★ [新增] 首选显卡 (空=自动选第一块) ★★★
         
         // ★★★ [新增] 首选风扇 ★★★
         public string PreferredCpuFan { get; set; } = "";

--- a/src/System/HardwareMonitor.cs
+++ b/src/System/HardwareMonitor.cs
@@ -497,6 +497,8 @@ namespace LiteMonitor.src.SystemServices
 
         public static List<string> ListAllDisks() => HardwareScanner.ListAllDisks(Instance!._computer);
 
+        public static List<string> ListAllGpus() => HardwareScanner.ListAllGpus(Instance!._computer);   // ★★★ [新增] ★★★
+
         public static List<string> ListAllFans() => HardwareScanner.ListAllFans(Instance!._computer, Instance!._lock);
 
         public static List<string> ListAllMoboTemps() => HardwareScanner.ListAllMoboTemps(Instance!._computer, Instance!._lock);

--- a/src/System/HardwareServices/HardwareScanner.cs
+++ b/src/System/HardwareServices/HardwareScanner.cs
@@ -14,6 +14,7 @@ namespace LiteMonitor.src.SystemServices
         private static List<string>? _cachedNetworkList = null;
         private static List<string>? _cachedDiskList = null;
         private static List<string>? _cachedMoboTempList = null;
+        private static List<string>? _cachedGpuList = null;   // ★★★ [新增] GPU 列表缓存 ★★★
 
         /// <summary>
         /// 清除所有扫描缓存
@@ -24,6 +25,7 @@ namespace LiteMonitor.src.SystemServices
             _cachedNetworkList = null;
             _cachedDiskList = null;
             _cachedMoboTempList = null;
+            _cachedGpuList = null;   // ★★★ [新增] ★★★
         }
 
         /// <summary>
@@ -70,6 +72,24 @@ namespace LiteMonitor.src.SystemServices
                 .Select(h => h.Name).Distinct().ToList();
 
             if (list.Count > 0) _cachedDiskList = list;
+            return list.ToList();
+        }
+
+        /// <summary>
+        /// ★★★ [新增] 列出所有显卡名称 (支持 NVIDIA / AMD / Intel) ★★★
+        /// </summary>
+        public static List<string> ListAllGpus(IComputer computer)
+        {
+            if (_cachedGpuList != null && _cachedGpuList.Count > 0)
+                return _cachedGpuList.ToList();
+
+            var list = computer.Hardware
+                .Where(h => h.HardwareType == HardwareType.GpuNvidia ||
+                            h.HardwareType == HardwareType.GpuAmd ||
+                            h.HardwareType == HardwareType.GpuIntel)
+                .Select(h => h.Name).Distinct().ToList();
+
+            if (list.Count > 0) _cachedGpuList = list;
             return list.ToList();
         }
 

--- a/src/System/HardwareServices/HardwareScanner.cs
+++ b/src/System/HardwareServices/HardwareScanner.cs
@@ -49,14 +49,14 @@ namespace LiteMonitor.src.SystemServices
         public static List<string> ListAllNetworks(IComputer computer)
         {
             if (_cachedNetworkList != null && _cachedNetworkList.Count > 0)
-                return _cachedNetworkList.ToList();
+                return new List<string>(_cachedNetworkList);
 
             var list = computer.Hardware
                 .Where(h => h.HardwareType == HardwareType.Network)
                 .Select(h => h.Name).Distinct().ToList();
 
             if (list.Count > 0) _cachedNetworkList = list;
-            return list.ToList();
+            return list;
         }
 
         /// <summary>
@@ -65,14 +65,14 @@ namespace LiteMonitor.src.SystemServices
         public static List<string> ListAllDisks(IComputer computer)
         {
             if (_cachedDiskList != null && _cachedDiskList.Count > 0)
-                return _cachedDiskList.ToList();
+                return new List<string>(_cachedDiskList);
 
             var list = computer.Hardware
                 .Where(h => h.HardwareType == HardwareType.Storage)
                 .Select(h => h.Name).Distinct().ToList();
 
             if (list.Count > 0) _cachedDiskList = list;
-            return list.ToList();
+            return list;
         }
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace LiteMonitor.src.SystemServices
         public static List<string> ListAllGpus(IComputer computer)
         {
             if (_cachedGpuList != null && _cachedGpuList.Count > 0)
-                return _cachedGpuList.ToList();
+                return new List<string>(_cachedGpuList);
 
             var list = computer.Hardware
                 .Where(h => h.HardwareType == HardwareType.GpuNvidia ||
@@ -90,7 +90,7 @@ namespace LiteMonitor.src.SystemServices
                 .Select(h => h.Name).Distinct().ToList();
 
             if (list.Count > 0) _cachedGpuList = list;
-            return list.ToList();
+            return list;
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace LiteMonitor.src.SystemServices
         public static List<string> ListAllFans(IComputer computer, object syncLock)
         {
             if (_cachedFanList != null && _cachedFanList.Count > 0)
-                return _cachedFanList.ToList();
+                return new List<string>(_cachedFanList);
 
             var list = new List<string>();
             lock (syncLock)
@@ -124,10 +124,9 @@ namespace LiteMonitor.src.SystemServices
                 foreach (var hw in computer.Hardware) Scan(hw);
             }
 
-            list.Sort();
-            var final = list.Distinct().ToList();
+            var final = list.Distinct().OrderBy(name => name).ToList();
             if (final.Count > 0) _cachedFanList = final;
-            return final.ToList();
+            return final;
         }
 
         /// <summary>
@@ -136,7 +135,7 @@ namespace LiteMonitor.src.SystemServices
         public static List<string> ListAllMoboTemps(IComputer computer, object syncLock)
         {
             if (_cachedMoboTempList != null && _cachedMoboTempList.Count > 0)
-                return _cachedMoboTempList.ToList();
+                return new List<string>(_cachedMoboTempList);
 
             var list = new List<string>();
             lock (syncLock)
@@ -161,10 +160,9 @@ namespace LiteMonitor.src.SystemServices
                 foreach (var hw in computer.Hardware) Scan(hw);
             }
 
-            list.Sort();
-            var final = list.Distinct().ToList();
+            var final = list.Distinct().OrderBy(name => name).ToList();
             if (final.Count > 0) _cachedMoboTempList = final;
-            return final.ToList();
+            return final;
         }
     }
 }

--- a/src/System/HardwareServices/HardwareValueProvider.cs
+++ b/src/System/HardwareServices/HardwareValueProvider.cs
@@ -36,6 +36,7 @@ namespace LiteMonitor.src.SystemServices
         private string _lastPrefMoboTemp = "";
         private string _lastPrefDisk = "";
         private string _lastPrefNet = "";
+        private string _lastPrefGpu = "";   // ★★★ [新增] 用户首选显卡 ★★★
         
         public HardwareValueProvider(Computer c, Settings s, SensorMap map, NetworkManager net, DiskManager disk, FpsCounter fpsCounter,PerformanceCounterManager perfManager, object syncLock, Dictionary<string, float> lastValid)
         {
@@ -65,6 +66,7 @@ namespace LiteMonitor.src.SystemServices
             _lastPrefMoboTemp = _cfg.PreferredMoboTemp;
             _lastPrefDisk = _cfg.PreferredDisk;
             _lastPrefNet = _cfg.PreferredNetwork;
+            _lastPrefGpu = _cfg.PreferredGpu ?? "";   // ★★★ [新增] ★★★
 
             // 1. 预查找用户指定的首选传感器 (风扇、水泵、主板温度)
             string[] preferredKeys = { "CPU.Fan", "CPU.Pump", "CASE.Fan", "MOBO.Temp" };
@@ -188,8 +190,16 @@ namespace LiteMonitor.src.SystemServices
             {
                 _tickCache.Clear();
 
-                // 自动检测配置变更：如果用户更改了首选风扇/磁盘，立即自动预热
-                if (_lastPrefCpuFan != _cfg.PreferredCpuFan ||
+                // ★★★ [新增] 检测 PreferredGpu 变更：需要重建 SensorMap (过滤逻辑在 Rebuild 里) ★★★
+                bool gpuChanged = _lastPrefGpu != (_cfg.PreferredGpu ?? "");
+                if (gpuChanged)
+                {
+                    _sensorMap.Rebuild(_computer, _cfg);
+                }
+
+                // 自动检测配置变更：如果用户更改了首选风扇/磁盘/显卡，立即自动预热
+                if (gpuChanged ||
+                    _lastPrefCpuFan != _cfg.PreferredCpuFan ||
                     _lastPrefCpuPump != _cfg.PreferredCpuPump ||
                     _lastPrefCaseFan != _cfg.PreferredCaseFan ||
                     _lastPrefMoboTemp != _cfg.PreferredMoboTemp ||

--- a/src/System/HardwareServices/SensorMap.cs
+++ b/src/System/HardwareServices/SensorMap.cs
@@ -62,6 +62,18 @@ namespace LiteMonitor.src.SystemServices
             }
         }
 
+        /// <summary>
+        /// ★★★ [新增] 使映射失效，强制下次 EnsureFresh 时重建 ★★★
+        /// 用于 PreferredGpu 等配置变更后立即生效
+        /// </summary>
+        public void Invalidate()
+        {
+            lock (_lock)
+            {
+                _lastMapBuild = DateTime.MinValue;
+            }
+        }
+
 
 
         public bool TryGetSensor(string key, out ISensor? sensor)
@@ -100,10 +112,25 @@ namespace LiteMonitor.src.SystemServices
             // 但为了保持原代码结构，我们依然用candidates收集主板相关数据
             var candidatesMoboTemps = new List<ISensor>(capacity: 10); // 预设容量，减少扩容开销
 
+            // ★★★ [新增] 读取用户首选显卡配置 (空=自动选第一块) ★★★
+            string prefGpu = cfg.PreferredGpu ?? "";
+
             // 局部递归函数
             void RegisterTo(IHardware hw)
             {
                 //hw.Update();
+
+                // ★★★ [新增] 首选显卡过滤：如果用户指定了首选 GPU，非匹配 GPU 完全跳过 ★★★
+                // 这样 newGpu 和 newMap["GPU.*"] 都只会来自用户指定的显卡
+                bool isGpuHw = hw.HardwareType == HardwareType.GpuNvidia ||
+                               hw.HardwareType == HardwareType.GpuAmd ||
+                               hw.HardwareType == HardwareType.GpuIntel;
+                if (isGpuHw && !string.IsNullOrEmpty(prefGpu) &&
+                    !hw.Name.Equals(prefGpu, StringComparison.OrdinalIgnoreCase))
+                {
+                    // 不处理该 GPU 的任何数据，也不递归其 SubHardware
+                    return;
+                }
 
                 // --- 填充 CPU 缓存 (用于加权平均) ---
                 if (hw.HardwareType == HardwareType.Cpu)

--- a/src/UI/Settings/SystemHardwarPage.cs
+++ b/src/UI/Settings/SystemHardwarPage.cs
@@ -17,6 +17,7 @@ namespace LiteMonitor.src.UI.SettingsPage
         
         // ★★★ 修复：类型更正为 LiteComboBox ★★★
         private LiteComboBox _cbDisk, _cbNet, _cbMobo;
+        private LiteComboBox _cbGpu;   // ★★★ [新增] 显卡下拉 ★★★
         private LiteComboBox _cbFanCpu, _cbFanPump, _cbFanCase;
 
         public SystemHardwarPage()
@@ -54,10 +55,11 @@ namespace LiteMonitor.src.UI.SettingsPage
                 // 1. 并行等待所有数据返回 (使用 HardwareScanner)
                 var taskDisks = Task.Run(() => HardwareScanner.ListAllDisks(HardwareMonitor.Instance.ComputerInstance));
                 var taskNets  = Task.Run(() => HardwareScanner.ListAllNetworks(HardwareMonitor.Instance.ComputerInstance));
+                var taskGpus  = Task.Run(() => HardwareScanner.ListAllGpus(HardwareMonitor.Instance.ComputerInstance));   // ★★★ [新增] ★★★
                 var taskFans  = Task.Run(() => HardwareScanner.ListAllFans(HardwareMonitor.Instance.ComputerInstance, HardwareMonitor.Instance.SyncLock));
                 var taskMobo  = Task.Run(() => HardwareScanner.ListAllMoboTemps(HardwareMonitor.Instance.ComputerInstance, HardwareMonitor.Instance.SyncLock));
 
-                await Task.WhenAll(taskDisks, taskNets, taskFans, taskMobo);
+                await Task.WhenAll(taskDisks, taskNets, taskGpus, taskFans, taskMobo);
 
                 // 2. ★★★ 锁定全局布局 (防止每填一个框就重绘一次) ★★★
                 this.SuspendLayout();
@@ -86,6 +88,7 @@ namespace LiteMonitor.src.UI.SettingsPage
                 // 3. 瞬间填入所有数据 (因为布局被挂起，用户看不见中间过程)
                 FillSync(_cbDisk, taskDisks.Result, Config.PreferredDisk);
                 FillSync(_cbNet, taskNets.Result, Config.PreferredNetwork);
+                FillSync(_cbGpu, taskGpus.Result, Config.PreferredGpu);   // ★★★ [新增] ★★★
                 FillSync(_cbMobo, taskMobo.Result, Config.PreferredMoboTemp);
                 
                 // Fan 的数据是复用的
@@ -136,6 +139,11 @@ namespace LiteMonitor.src.UI.SettingsPage
             _cbDisk = (LiteComboBox)group.AddCombo(this, "Menu.DiskSource", new List<string> { strAuto }, 
                 () => Config?.PreferredDisk ?? strAuto, 
                 v => { if(Config!=null) Config.PreferredDisk = (v == strAuto ? "" : v); });
+
+            // ★★★ [新增] 显卡来源下拉：多显卡设备 (笔记本核显+独显) 可选择显示哪块 ★★★
+            _cbGpu = (LiteComboBox)group.AddCombo(this, "Menu.GpuSource", new List<string> { strAuto },
+                () => Config?.PreferredGpu ?? strAuto,
+                v => { if (Config != null) Config.PreferredGpu = (v == strAuto ? "" : v); });
 
             _cbNet = (LiteComboBox)group.AddCombo(this, "Menu.NetworkSource", new List<string> { strAuto },
                 () => Config?.PreferredNetwork ?? strAuto,


### PR DESCRIPTION
## 背景

多显卡笔记本（AMD/Intel 核显 + NVIDIA 独显的组合）当前无法选择 GPU 监控项显示哪块显卡。在我的设备上（AMD Ryzen 7 H 255 + Radeon 780M + NVIDIA RTX 5060 Laptop，独显直连模式），GPU 分组默认锁定 AMD 核显，无法读取到独显数据。

「系统硬件详情」面板能正常识别两块显卡的所有传感器，说明 LibreHardwareMonitorLib 已经拿到了数据，只是上层没提供切换入口。

## 实现方案

新增 `Settings.PreferredGpu` 配置字段，完全参照现有 `PreferredDisk` / `PreferredCpuFan` 等首选设备字段的模式。在「设置 → 硬件与系统」面板增加「首选显卡」下拉框，UI 实现照抄现有磁盘/网卡下拉。

核心过滤逻辑放在 `SensorMap.Rebuild` 中：遍历硬件时，若 `PreferredGpu` 非空，跳过名称不匹配的 GPU 硬件，确保所有 `GPU.*` 传感器键都绑定到用户指定的显卡。

`HardwareValueProvider.OnUpdateTickStarted` 检测到 `PreferredGpu` 变更时，触发 `SensorMap.Rebuild` 并重新 `PreCacheAllSensors`，用户改变选择后无需重启软件即可生效。

## 改动文件

- `src/Core/Settings.cs` - 新增 `PreferredGpu` 字段
- `src/System/HardwareServices/HardwareScanner.cs` - 新增 `ListAllGpus` 方法
- `src/System/HardwareServices/SensorMap.cs` - Rebuild 支持按 PreferredGpu 过滤 + 新增 `Invalidate()` 方法
- `src/System/HardwareServices/HardwareValueProvider.cs` - 检测 GPU 变更并触发重建
- `src/System/HardwareMonitor.cs` - 暴露 `ListAllGpus` 静态方法
- `src/UI/Settings/SystemHardwarPage.cs` - 新增 GPU 下拉框
- `resources/lang/zh.json` / `en.json` - 新增 `Menu.GpuSource` 翻译

## 兼容性

- 默认值 `""` = 自动模式 = 原有行为，对现有用户无感知
- 单显卡用户下拉只有「自动模式」一个选项，无副作用
- 不引入新依赖
- 编译通过，无新增 error 或 warning
- 遵循 `SETTINGS_README_DEV.md` 的 Draft-Commit 规范（仅加配置字段 + UI 绑定，`SettingsChanger.Merge` 会自动通过反射处理新字段）

## 测试

在 AMD 780M + RTX 5060 Laptop 笔记本上验证：
- 默认「自动模式」：显示 AMD 核显（与修改前行为完全一致）
- 选择「NVIDIA GeForce RTX 5060 Laptop GPU」：GPU 温度/负载/功耗/频率/显存/风扇全部切到独显
- 切回「AMD Radeon 780M Graphics」：无缝切换回核显
- 热切换无需重启软件

对比任务管理器和其它监控软件的 NVIDIA GPU 数据一致（排除采样时刻差异）。