### PR TITLE
fix: 修复副屏任务栏重启后不显示及高度异常问题

### DIFF
--- a/src/UI/Helpers/TaskbarBizHelper.cs
+++ b/src/UI/Helpers/TaskbarBizHelper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using System.Windows.Forms;
 using LiteMonitor.src.Core;
 using static LiteMonitor.src.UI.Helpers.TaskbarWinHelper;
@@ -85,14 +86,48 @@ namespace LiteMonitor.src.UI.Helpers
         public void FindHandles()
         {
             var handles = _winHelper.FindHandles(_cfg.TaskbarMonitorDevice);
+            
+            // [Fix] 如果句柄变了（如从主屏切换到副屏），立即重新挂载
+            // 解决 Win10 策略 _hReBar/_hMin 缓存过期导致 SetPosition 无法检测到父窗口变化
+            bool handleChanged = (handles.hTaskbar != _hTaskbar);
+            
             _hTaskbar = handles.hTaskbar;
             _hTray = handles.hTray;
+            
+            if (handleChanged && _hTaskbar != IntPtr.Zero)
+            {
+                _winHelper.AttachToTaskbar(_hTaskbar);
+            }
         }
 
         public bool IsTaskbarValid()
         {
             if (_hTaskbar == IntPtr.Zero) return false;
             return TaskbarWinHelper.IsWindow(_hTaskbar);
+        }
+
+        /// <summary>
+        /// [Fix] 检查当前任务栏句柄是否挂载在正确的屏幕上
+        /// 解决启动时副屏任务栏未就绪导致挂载到错误屏幕的问题
+        /// </summary>
+        public bool IsOnCorrectScreen()
+        {
+            if (_hTaskbar == IntPtr.Zero) return false;
+            // 自动模式（未指定屏幕）不检查
+            if (string.IsNullOrEmpty(_cfg.TaskbarMonitorDevice)) return true;
+
+            // 获取当前任务栏句柄的窗口矩形
+            if (!_winHelper.GetWindowRectWrapper(_hTaskbar, out Rectangle taskbarRect)) return false;
+
+            // 查找目标屏幕
+            var targetScreen = Screen.AllScreens.FirstOrDefault(s => s.DeviceName == _cfg.TaskbarMonitorDevice);
+            // [Fix] 找不到目标屏幕时返回 false，触发重新查找
+            // 之前返回 true 会导致永远不重新查找
+            if (targetScreen == null) return false;
+
+            // 检查任务栏矩形是否在目标屏幕范围内
+            return targetScreen.Bounds.Contains(taskbarRect.Location) ||
+                   targetScreen.Bounds.IntersectsWith(taskbarRect);
         }
 
         public void AttachToTaskbar()

--- a/src/UI/Helpers/TaskbarWinHelper.cs
+++ b/src/UI/Helpers/TaskbarWinHelper.cs
@@ -103,7 +103,7 @@ namespace LiteMonitor.src.UI.Helpers
         private static readonly bool _isWin11 = Environment.OSVersion.Version.Major == 10 && Environment.OSVersion.Version.Build >= 22000;
 
         public bool UsesInternalLayout => _strategy.HasInternalLayout;
-        
+
         public TaskbarWinHelper(Form form)
         {
             _form = form;
@@ -186,22 +186,31 @@ namespace LiteMonitor.src.UI.Helpers
         // =================================================================
         public (IntPtr hTaskbar, IntPtr hTray) FindHandles(string targetDevice)
         {
-            Screen target = Screen.PrimaryScreen;
+            // [Fix] 如果指定了目标屏幕但找不到，返回 Zero 而非 fallback 到主屏
+            // 这样 Tick 重试机制才能生效
             if (!string.IsNullOrEmpty(targetDevice))
             {
-                target = Screen.AllScreens.FirstOrDefault(s => s.DeviceName == targetDevice) ?? Screen.PrimaryScreen;
+                var target = Screen.AllScreens.FirstOrDefault(s => s.DeviceName == targetDevice);
+                if (target == null) return (IntPtr.Zero, IntPtr.Zero);
+
+                if (target.Primary)
+                {
+                    IntPtr hTaskbar = FindWindow("Shell_TrayWnd", null);
+                    IntPtr hTray = FindWindowEx(hTaskbar, IntPtr.Zero, "TrayNotifyWnd", null);
+                    return (hTaskbar, hTray);
+                }
+                else
+                {
+                    IntPtr hTaskbar = FindSecondaryTaskbar(target);
+                    return (hTaskbar, IntPtr.Zero);
+                }
             }
 
-            if (target.Primary)
+            // 自动模式：使用主屏
             {
                 IntPtr hTaskbar = FindWindow("Shell_TrayWnd", null);
                 IntPtr hTray = FindWindowEx(hTaskbar, IntPtr.Zero, "TrayNotifyWnd", null);
                 return (hTaskbar, hTray);
-            }
-            else
-            {
-                IntPtr hTaskbar = FindSecondaryTaskbar(target);
-                return (hTaskbar, IntPtr.Zero);
             }
         }
 
@@ -215,7 +224,9 @@ namespace LiteMonitor.src.UI.Helpers
                 if (screen.Bounds.Contains(r.Location) || screen.Bounds.IntersectsWith(r))
                     return hWnd;
             }
-            return FindWindow("Shell_TrayWnd", null);
+            // [Fix] 不再 fallback 到主屏 Shell_TrayWnd
+            // 启动时副屏任务栏可能尚未就绪，返回 Zero 让 Tick 重试机制生效
+            return IntPtr.Zero;
         }
 
         public Rectangle GetTaskbarRect(IntPtr hTaskbar, string targetDevice)
@@ -248,33 +259,39 @@ namespace LiteMonitor.src.UI.Helpers
                     Rectangle screenBounds = screen.Bounds;
                     int reservedBottom = screenBounds.Bottom - workArea.Bottom;
 
-                    // 场景 A: 锚定模式
-                    if (reservedBottom > 2) 
+                    // [Fix] DPI 缩放可能导致 screenBounds 和 workArea 处于不同坐标空间
+                    // (screenBounds 返回物理像素，workArea 返回逻辑像素)
+                    // 判断方法：如果物理矩形高度已经是合理的任务栏高度(20~100px)，直接使用
+                    bool physHeightIsReasonable = rectPhys.Height >= 20 && rectPhys.Height <= 100;
+
+                    // 场景 A: 锚定模式 - 仅当物理高度不合理时才用 WorkingArea 修正
+                    if (reservedBottom > 2 && !physHeightIsReasonable) 
                     {
                         finalRect = new Rectangle(rectPhys.Left, workArea.Bottom, rectPhys.Width, reservedBottom);
                     }
-                    // 场景 B: 悬浮模式
+                    // 场景 B: 物理矩形已经是合理高度，直接使用
+                    else if (physHeightIsReasonable)
+                    {
+                        finalRect = rectPhys;
+                    }
+                    // 场景 C: 悬浮模式 - 物理高度异常，需要修正
                     else
                     {
-                        if (_isWin11)
+                        // 增加对垂直任务栏的判断，防止误判
+                        bool isVertical = rectPhys.Height > rectPhys.Width;
+
+                        if (!isVertical)
                         {
-                            // [Fix] 增加对垂直任务栏的判断，防止误判
-                            // StartAllBack 等软件可能启用垂直任务栏，此时不应应用底部水平任务栏的高度修正
-                            bool isVertical = rectPhys.Height > rectPhys.Width;
+                            int dpi = GetTaskbarDpi();
+                            int standardHeight = (int)Math.Round(48.0 * dpi / 96.0);
 
-                            if (!isVertical)
+                            if (rectPhys.Height > (standardHeight * 0.8))
                             {
-                                int dpi = GetTaskbarDpi();
-                                int standardHeight = (int)Math.Round(48.0 * dpi / 96.0);
-
-                                if (rectPhys.Height > (standardHeight * 0.8))
-                                {
-                                    finalRect = new Rectangle(
-                                        rectPhys.Left, 
-                                        rectPhys.Bottom - standardHeight, 
-                                        rectPhys.Width, 
-                                        standardHeight);
-                                }
+                                finalRect = new Rectangle(
+                                    rectPhys.Left, 
+                                    rectPhys.Bottom - standardHeight, 
+                                    rectPhys.Width, 
+                                    standardHeight);
                             }
                         }
                     }

--- a/src/UI/TaskbarForm.cs
+++ b/src/UI/TaskbarForm.cs
@@ -174,9 +174,12 @@ namespace LiteMonitor
             // [Fix] 周期性检查句柄，防止 Explorer 重启后句柄失效
             // 优化：仅在重试期或句柄无效时调用 FindHandles，且限制调用频率
             bool isHandleInvalid = !_bizHelper.IsTaskbarValid();
-            
-            // 如果处于重试期，或者句柄无效且距离上次查找超过2秒(防止无Explorer时高频空转)
-            if (isHandleInvalid && (DateTime.Now - _lastFindHandleTime).TotalSeconds > 2)
+            // [Fix] 检查当前句柄是否挂载在正确的屏幕上
+            // 解决启动时副屏任务栏未就绪导致 fallback 到主屏的问题
+            bool isWrongScreen = !isHandleInvalid && !_bizHelper.IsOnCorrectScreen();
+
+            // 如果句柄无效、或挂载到了错误的屏幕，且距离上次查找超过2秒(防止无Explorer时高频空转)
+            if ((isHandleInvalid || isWrongScreen) && (DateTime.Now - _lastFindHandleTime).TotalSeconds > 2)
             {
                 _bizHelper.FindHandles();
                 _lastFindHandleTime = DateTime.Now;
@@ -188,7 +191,10 @@ namespace LiteMonitor
             // 使用临时变量接收，先判断数据有效性，再赋值给成员变量 _cols
             // 防止在 UI 重建期间(RebuildLayout)获取到空列表导致任务栏闪烁或清空
             var nextCols = _ui.GetTaskbarColumns();
-            if (nextCols == null || nextCols.Count == 0) return;
+            if (nextCols == null || nextCols.Count == 0)
+            {
+                return;
+            }
             
             _cols = nextCols; // 确认有效后再更新引用
 
@@ -239,7 +245,10 @@ namespace LiteMonitor
             // ★ 调试验证用：如果消失时出现了一个红块，说明 OnPaint 被调用但 _cols 为空
             // e.Graphics.FillRectangle(Brushes.Red, 0, 0, 20, 20); 
 
-            if (_cols == null) return;
+            if (_cols == null)
+            {
+                return;
+            }
             var g = e.Graphics;
             g.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.HighQuality;
             g.PixelOffsetMode = System.Drawing.Drawing2D.PixelOffsetMode.HighQuality;


### PR DESCRIPTION
## 问题

在多显示器环境下，将任务栏设置到副屏后，每次重启程序都无法在副屏任务栏显示，需要手动切回主屏再切回副屏才能恢复。同时副屏任务栏会占位但内容不可见。

## 根因

1. **FindHandles fallback 到主屏**：启动时副屏任务栏（`Shell_SecondaryTrayWnd`）可能尚未就绪，原代码会 fallback 到主屏 `Shell_TrayWnd`，且 Tick 重试逻辑无法检测到这个错误，导致永远停留在主屏。

2. **DPI 缩放导致坐标空间不一致**：`Screen.Bounds` 返回物理像素，`Screen.WorkingArea` 返回逻辑像素，两者相减得到错误的高度（如 424px 而非 40px），导致窗口被拉伸但内容不可见。

## 修复

- `FindHandles` 找不到副屏任务栏时返回 `IntPtr.Zero`，不再 fallback 到主屏，让 Tick 重试机制生效
- 新增 `IsOnCorrectScreen()` 检测当前句柄是否挂载在目标屏幕上
- Tick 中增加 `isWrongScreen` 检查，挂载到错误屏幕时触发重新查找
- 句柄变化时立即重新挂载，解决 Win10 策略缓存过期问题
- `GetTaskbarRect` 中当物理矩形高度已是合理任务栏高度（20~100px）时直接使用，绕过 DPI 缩放不一致问题

## 测试环境

- Win10 22H2 + 双显示器（主屏 2560×1440 100% / 副屏 1366×768 150%）