### PR TITLE
fix(taskbar): recover integration after resume and display changes

### DIFF
--- a/src/UI/Helpers/TaskbarBizHelper.cs
+++ b/src/UI/Helpers/TaskbarBizHelper.cs
@@ -95,6 +95,23 @@ namespace LiteMonitor.src.UI.Helpers
             return TaskbarWinHelper.IsWindow(_hTaskbar);
         }
 
+        public bool IsTaskbarIntegrationValid()
+        {
+            return IsTaskbarValid() && _winHelper.IsAttachedToTaskbar(_hTaskbar);
+        }
+
+        public bool RecoverTaskbarIntegration()
+        {
+            _winHelper.InvalidateTaskbarRectCache();
+            FindHandles();
+
+            if (!IsTaskbarValid()) return false;
+
+            AttachToTaskbar();
+            UpdateTaskbarRect();
+            return !_taskbarRect.IsEmpty;
+        }
+
         public void AttachToTaskbar()
         {
             if (_hTaskbar == IntPtr.Zero) FindHandles();

--- a/src/UI/Helpers/TaskbarStrategyWin10.cs
+++ b/src/UI/Helpers/TaskbarStrategyWin10.cs
@@ -28,7 +28,10 @@ namespace LiteMonitor.src.UI.Helpers
 
         // 优化配置
         private const int GAP_TOLERANCE = 1; // 容忍 1px 的误差，防止反复重绘造成的闪烁
-        public bool IsReady => _hReBar != IntPtr.Zero && _hMin != IntPtr.Zero;
+        public bool IsReady => _hReBar != IntPtr.Zero &&
+                               _hMin != IntPtr.Zero &&
+                               IsWindow(_hReBar) &&
+                               IsWindow(_hMin);
 
         public bool HasInternalLayout => true;
 
@@ -87,16 +90,28 @@ namespace LiteMonitor.src.UI.Helpers
 
         private void InitializeHandles(IntPtr hTaskbar)
         {
+            IntPtr previousReBar = _hReBar;
+            IntPtr previousMin = _hMin;
+
             // Win10 结构：Shell_TrayWnd -> ReBarWindow32 -> MSTaskSwWClass
             _hReBar = FindWindowEx(hTaskbar, IntPtr.Zero, "ReBarWindow32", null);
             if (_hReBar == IntPtr.Zero)
                 _hReBar = FindWindowEx(hTaskbar, IntPtr.Zero, "WorkerW", null); 
 
+            _hMin = IntPtr.Zero;
             if (_hReBar != IntPtr.Zero)
             {
                 _hMin = FindWindowEx(_hReBar, IntPtr.Zero, "MSTaskSwWClass", null);
                 if (_hMin == IntPtr.Zero)
                     _hMin = FindWindowEx(_hReBar, IntPtr.Zero, "MSTaskListWClass", null); 
+            }
+
+            if (_hReBar != previousReBar || _hMin != previousMin)
+            {
+                _lastSqueezedWidth = -1;
+                _lastUsedWidth = 0;
+                _lastSqueezedHeight = -1;
+                _lastUsedHeight = 0;
             }
         }
 

--- a/src/UI/Helpers/TaskbarWinHelper.cs
+++ b/src/UI/Helpers/TaskbarWinHelper.cs
@@ -57,10 +57,14 @@ namespace LiteMonitor.src.UI.Helpers
         public const int WS_EX_LAYERED = 0x80000;
         public const int WS_EX_TOOLWINDOW = 0x00000080;
         public const uint LWA_COLORKEY = 0x00000001;
+        public const uint SWP_NOSIZE = 0x0001;
+        public const uint SWP_NOMOVE = 0x0002;
         public const uint SWP_NOZORDER = 0x0004;
         public const uint SWP_NOACTIVATE = 0x0010;
+        public const uint SWP_SHOWWINDOW = 0x0040;
         public const int WS_EX_TRANSPARENT = 0x00000020;
         public const int DWMWA_EXTENDED_FRAME_BOUNDS = 9;
+        public static readonly IntPtr HWND_TOP = IntPtr.Zero;
 
         [StructLayout(LayoutKind.Sequential)]
         public struct POINT { public int X, Y; }
@@ -98,6 +102,11 @@ namespace LiteMonitor.src.UI.Helpers
         private Rectangle _lastWindowRect = Rectangle.Empty;
         private Rectangle _cachedResult = Rectangle.Empty;
         private bool _isCacheValid = false;
+        private IntPtr _lastTaskbarHandle = IntPtr.Zero;
+        private string _lastTargetDevice = string.Empty;
+        private Rectangle _lastScreenBounds = Rectangle.Empty;
+        private Rectangle _lastWorkingArea = Rectangle.Empty;
+        private uint _lastTaskbarDpi = 96;
 
         // [Optimization] 静态缓存系统版本检测结果
         private static readonly bool _isWin11 = Environment.OSVersion.Version.Major == 10 && Environment.OSVersion.Version.Build >= 22000;
@@ -160,6 +169,36 @@ namespace LiteMonitor.src.UI.Helpers
         public void AttachToTaskbar(IntPtr taskbarHandle)
         {
             _strategy.Attach(taskbarHandle);
+
+            // Explorer 在启动/唤醒时可能保留父子关系，却把窗口排到新的任务栏层后面。
+            // 每次恢复集成时重新确认可见性和同级 Z 序，但不激活窗口。
+            if (_form.IsHandleCreated && IsWindow(_form.Handle))
+            {
+                SetWindowPos(
+                    _form.Handle,
+                    HWND_TOP,
+                    0,
+                    0,
+                    0,
+                    0,
+                    SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_SHOWWINDOW);
+            }
+        }
+
+        public bool IsAttachedToTaskbar(IntPtr taskbarHandle)
+        {
+            if (taskbarHandle == IntPtr.Zero || !_form.IsHandleCreated || !IsWindow(_form.Handle))
+                return false;
+
+            IntPtr expectedParent = _strategy.GetExpectedParent(taskbarHandle);
+            return expectedParent != IntPtr.Zero &&
+                   IsWindow(expectedParent) &&
+                   GetParent(_form.Handle) == expectedParent;
+        }
+
+        public void InvalidateTaskbarRectCache()
+        {
+            _isCacheValid = false;
         }
 
         public void SetPosition(IntPtr taskbarHandle, int left, int top, int w, int h, int manualOffset = 0, bool alignLeft = true)
@@ -226,8 +265,40 @@ namespace LiteMonitor.src.UI.Helpers
             if (!GetWindowRect(hTaskbar, out RECT r)) return Rectangle.Empty;
             var rectPhys = Rectangle.FromLTRB(r.left, r.top, r.right, r.bottom);
 
-            // 缓存检查
-            if (_isCacheValid && rectPhys == _lastWindowRect) return _cachedResult;
+            Screen? screen = null;
+            Rectangle screenBounds = Rectangle.Empty;
+            Rectangle workingArea = Rectangle.Empty;
+            uint taskbarDpi = 96;
+
+            try
+            {
+                if (!string.IsNullOrEmpty(targetDevice))
+                    screen = Screen.AllScreens.FirstOrDefault(s => s.DeviceName == targetDevice);
+                screen ??= Screen.FromHandle(hTaskbar);
+
+                if (screen != null)
+                {
+                    screenBounds = screen.Bounds;
+                    workingArea = screen.WorkingArea;
+                }
+
+                taskbarDpi = GetDpiForWindow(hTaskbar);
+                if (taskbarDpi == 0) taskbarDpi = 96;
+            }
+            catch { }
+
+            // 任务栏 HWND 可能在显示器、DPI、工作区变化后继续有效。
+            // 旧缓存只比较物理矩形，会一直复用过期坐标，直到整个程序重启。
+            if (_isCacheValid &&
+                hTaskbar == _lastTaskbarHandle &&
+                string.Equals(targetDevice, _lastTargetDevice, StringComparison.Ordinal) &&
+                rectPhys == _lastWindowRect &&
+                screenBounds == _lastScreenBounds &&
+                workingArea == _lastWorkingArea &&
+                taskbarDpi == _lastTaskbarDpi)
+            {
+                return _cachedResult;
+            }
 
             Rectangle finalRect = rectPhys;
 
@@ -236,22 +307,14 @@ namespace LiteMonitor.src.UI.Helpers
             // =========================================================================
             try
             {
-                Screen screen = null;
-                if (!string.IsNullOrEmpty(targetDevice)) 
-                    screen = Screen.AllScreens.FirstOrDefault(s => s.DeviceName == targetDevice);
-                if (screen == null) 
-                    screen = Screen.FromHandle(hTaskbar);
-
                 if (screen != null)
                 {
-                    Rectangle workArea = screen.WorkingArea;
-                    Rectangle screenBounds = screen.Bounds;
-                    int reservedBottom = screenBounds.Bottom - workArea.Bottom;
+                    int reservedBottom = screenBounds.Bottom - workingArea.Bottom;
 
                     // 场景 A: 锚定模式
                     if (reservedBottom > 2) 
                     {
-                        finalRect = new Rectangle(rectPhys.Left, workArea.Bottom, rectPhys.Width, reservedBottom);
+                        finalRect = new Rectangle(rectPhys.Left, workingArea.Bottom, rectPhys.Width, reservedBottom);
                     }
                     // 场景 B: 悬浮模式
                     else
@@ -264,8 +327,7 @@ namespace LiteMonitor.src.UI.Helpers
 
                             if (!isVertical)
                             {
-                                int dpi = GetTaskbarDpi();
-                                int standardHeight = (int)Math.Round(48.0 * dpi / 96.0);
+                                int standardHeight = (int)Math.Round(48.0 * taskbarDpi / 96.0);
 
                                 if (rectPhys.Height > (standardHeight * 0.8))
                                 {
@@ -284,6 +346,11 @@ namespace LiteMonitor.src.UI.Helpers
 
             _lastWindowRect = rectPhys;
             _cachedResult = finalRect;
+            _lastTaskbarHandle = hTaskbar;
+            _lastTargetDevice = targetDevice ?? string.Empty;
+            _lastScreenBounds = screenBounds;
+            _lastWorkingArea = workingArea;
+            _lastTaskbarDpi = taskbarDpi;
             _isCacheValid = true;
 
             return _cachedResult;

--- a/src/UI/MainForm_Transparent.cs
+++ b/src/UI/MainForm_Transparent.cs
@@ -21,7 +21,10 @@ namespace LiteMonitor
         private readonly MainFormBizHelper _bizHelper;
         private readonly int _wmTaskbarCreated;
         private const int WM_DISPLAYCHANGE = 0x007E;
-        private CancellationTokenSource _displayChangeCts;
+        private const int WM_POWERBROADCAST = 0x0218;
+        private const int PBT_APMRESUMESUSPEND = 0x0007;
+        private const int PBT_APMRESUMEAUTOMATIC = 0x0012;
+        private CancellationTokenSource? _displayChangeCts;
 
         private Point _dragOffset;
         private bool _uiDragging = false;
@@ -258,6 +261,15 @@ namespace LiteMonitor
                 }
             }
 
+            if (m.Msg == WM_POWERBROADCAST &&
+                (m.WParam.ToInt32() == PBT_APMRESUMESUSPEND ||
+                 m.WParam.ToInt32() == PBT_APMRESUMEAUTOMATIC))
+            {
+                // Modern Standby 唤醒后，任务栏根 HWND 往往仍有效，
+                // 但其子窗口、Z 序和显示器坐标已经被重建。
+                _taskbar?.RequestTaskbarRecovery();
+            }
+
             if (m.Msg == WM_DISPLAYCHANGE)
             {
                 // [Fix #288] 分辨率改变后，延迟执行位置恢复，确保 Screen.AllScreens 已完全更新
@@ -270,7 +282,11 @@ namespace LiteMonitor
                 {
                     if (!t.IsCanceled)
                     {
-                        this.BeginInvoke(new Action(() => _bizHelper?.RestorePos()));
+                        this.BeginInvoke(new Action(() =>
+                        {
+                            _bizHelper?.RestorePos();
+                            _taskbar?.RequestTaskbarRecovery();
+                        }));
                     }
                 });
             }
@@ -291,6 +307,7 @@ namespace LiteMonitor
             base.OnDpiChanged(e);
             _ui?.ApplyTheme(_cfg.Skin);
             _winHelper.ApplyRoundedCorners();
+            _taskbar?.RequestTaskbarRecovery();
             this.Invalidate();
         }
 

--- a/src/UI/TaskbarForm.cs
+++ b/src/UI/TaskbarForm.cs
@@ -23,6 +23,7 @@ namespace LiteMonitor
         private List<Column>? _cols;
         private ContextMenuStrip? _currentMenu;
         private DateTime _lastFindHandleTime = DateTime.MinValue;
+        private DateTime _recoveryEndTime = DateTime.Now.AddSeconds(10);
         private string _lastLayoutSignature = "";
         private readonly TaskbarTooltipHelper _tooltipHelper;
         
@@ -60,9 +61,8 @@ namespace LiteMonitor
             ReloadLayout();
 
             _bizHelper.CheckTheme(true);
-            _bizHelper.FindHandles();
-            
-            _bizHelper.AttachToTaskbar();
+            _bizHelper.RecoverTaskbarIntegration();
+            _lastFindHandleTime = DateTime.Now;
             _winHelper.ApplyLayeredStyle(_bizHelper.TransparentKey, _cfg.TaskbarClickThrough);
 
             _timer.Interval = Math.Max(_cfg.RefreshMs, 60);
@@ -73,6 +73,15 @@ namespace LiteMonitor
             _tooltipHelper = new TaskbarTooltipHelper(this, _cfg, _ui);
 
             Tick();
+        }
+
+        public void RequestTaskbarRecovery()
+        {
+            if (IsDisposed) return;
+
+            // 覆盖登录、唤醒或显示拓扑变化后 Explorer 重建任务栏子窗口的时间段。
+            _recoveryEndTime = DateTime.Now.AddSeconds(10);
+            _lastFindHandleTime = DateTime.MinValue;
         }
 
         public void ReloadLayout()
@@ -171,15 +180,17 @@ namespace LiteMonitor
 
         private void Tick()
         {
-            // [Fix] 周期性检查句柄，防止 Explorer 重启后句柄失效
-            // 优化：仅在重试期或句柄无效时调用 FindHandles，且限制调用频率
-            bool isHandleInvalid = !_bizHelper.IsTaskbarValid();
+            // 恢复期内即使旧的任务栏根 HWND 仍有效，也要重新查找并挂载。
+            // Explorer 经常保留根 HWND，却在其下重建子层级和显示坐标。
+            DateTime now = DateTime.Now;
+            bool isInRecoveryPeriod = now < _recoveryEndTime;
+            bool isIntegrationInvalid = !_bizHelper.IsTaskbarIntegrationValid();
             
-            // 如果处于重试期，或者句柄无效且距离上次查找超过2秒(防止无Explorer时高频空转)
-            if (isHandleInvalid && (DateTime.Now - _lastFindHandleTime).TotalSeconds > 2)
+            if ((isInRecoveryPeriod || isIntegrationInvalid) &&
+                (now - _lastFindHandleTime).TotalSeconds > 2)
             {
-                _bizHelper.FindHandles();
-                _lastFindHandleTime = DateTime.Now;
+                _bizHelper.RecoverTaskbarIntegration();
+                _lastFindHandleTime = now;
             }
 
             if (Math.Abs(Environment.TickCount) % 5000 < _cfg.RefreshMs) _bizHelper.CheckTheme();


### PR DESCRIPTION
## 问题

LiteMonitor 1.3.6 在登录启动、Modern Standby 唤醒或显示拓扑变化后，可能出现任务栏监控条消失/错位，但进程仍在运行，重启程序后恢复。

本地排查环境为 Windows 11 25H2 (26200.9168)、双屏、LiteMonitor 1.3.6。故障发生时没有 LiteMonitor 崩溃日志，Explorer 也没有重启；这与 #512、#539、#487、#355、#344 中“进程仍在、重启恢复”的现象一致。

## 原因

- `TaskbarForm` 只在任务栏根 HWND 已失效时重新查找句柄；但 Explorer 在登录、唤醒和显示变化时经常保留根 HWND，同时重建子窗口、Z 序和显示器几何信息。
- 2026-01-23 的任务栏监听重构移除了 `TaskbarForm` 原有的启动重试窗口，新实例实际上不再执行注释所说的“自带重试机制”。
- 任务栏矩形缓存只比较根窗口物理矩形，没有把任务栏 HWND、目标显示器、屏幕边界、工作区和 DPI 纳入缓存键。
- `WM_DISPLAYCHANGE` 目前只恢复主面板位置；Modern Standby 唤醒没有触发任务栏重新集成。
- Win10 策略只检查内部句柄是否非零，没有验证 `ReBarWindow32` / `MSTaskSwWClass` 是否仍是有效窗口。

## 修改

- 启动及恢复期内每 2 秒重新解析并挂载任务栏，持续 10 秒；恢复期结束后仍会在集成失效时重试。
- 处理 `WM_POWERBROADCAST` 的恢复消息，并在显示器/DPI 变化后请求任务栏恢复。
- 恢复时清空任务栏矩形缓存，重新确认子窗口可见性和同级 Z 序，但不激活窗口。
- 扩展任务栏矩形缓存键，覆盖 HWND、目标显示器、屏幕边界、工作区和 DPI。
- 验证 Win10 内部任务栏句柄，并在句柄变化时重置布局跟踪状态。

## 验证

- `.NET SDK 8.0.424`
- `dotnet restore LiteMonitor.sln`
- Release 全量构建：0 warnings / 0 errors（仓库未跟踪但 csproj 引用的 `使用说明(必读).txt` 使用发布包中的文件补齐后构建）
- Windows 11 25H2 双屏启动冒烟测试：测试版在启动后 3 秒与 12 秒均保持为 `Shell_TrayWnd` 的可见子窗口，父句柄和任务栏坐标稳定，无错误日志
- 未主动让当前工作会话睡眠或切换真实分辨率；对应消息路径和恢复窗口已实现，仍建议在 #512 / #539 的可复现环境中复测

Relates to #512, #539, #487, #355, #344, #303.