### PR TITLE
fix: 修复多屏自动隐藏、设置保存回退和缩放后文字挤压

### DIFF
--- a/src/Core/Actions/SettingsChanger.cs
+++ b/src/Core/Actions/SettingsChanger.cs
@@ -132,28 +132,49 @@ namespace LiteMonitor.src.Core.Actions
         {
             if (live?.MonitorItems == null || draft == null) return;
 
-            // 1. 通过序列化进行深拷贝，断开引用关联
-            // 注意：这会丢失 [JsonIgnore] 的动态属性
-            var json = System.Text.Json.JsonSerializer.Serialize(live.MonitorItems);
-            var newItems = System.Text.Json.JsonSerializer.Deserialize<List<MonitorItemConfig>>(json) 
-                           ?? new List<MonitorItemConfig>();
-
-            // 2. 恢复动态属性 (Runtime State)
-            // 因为 Draft 是给 UI 用的，必须包含当前的显示名称
-            var liveMap = live.MonitorItems.ToDictionary(x => x.Key);
-            
-            foreach (var item in newItems)
+            // 运行时可能会添加/删除插件监控项，或更新动态标签；但用户在 Draft
+            // 中编辑的可见性、名称、单位和排序必须优先保留，不能被 Live 整体覆盖。
+            var liveMap = new Dictionary<string, MonitorItemConfig>(StringComparer.OrdinalIgnoreCase);
+            foreach (var liveItem in live.MonitorItems)
             {
-                if (liveMap.TryGetValue(item.Key, out var liveItem))
-                {
-                    item.DynamicLabel = liveItem.DynamicLabel;
-                    item.DynamicTaskbarLabel = liveItem.DynamicTaskbarLabel;
-                }
+                if (liveItem != null && !string.IsNullOrEmpty(liveItem.Key) && !liveMap.ContainsKey(liveItem.Key))
+                    liveMap[liveItem.Key] = liveItem;
             }
 
-            draft.MonitorItems = newItems;
+            var mergedItems = new List<MonitorItemConfig>();
+            var retainedKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            // 按 Draft 原有顺序保留仍然存在的用户配置。
+            foreach (var draftItem in draft.MonitorItems ?? new List<MonitorItemConfig>())
+            {
+                if (draftItem == null || string.IsNullOrEmpty(draftItem.Key) ||
+                    !liveMap.TryGetValue(draftItem.Key, out var liveItem) ||
+                    !retainedKeys.Add(draftItem.Key))
+                    continue;
+
+                draftItem.DynamicLabel = liveItem.DynamicLabel;
+                draftItem.DynamicTaskbarLabel = liveItem.DynamicTaskbarLabel;
+                mergedItems.Add(draftItem);
+            }
+
+            // 将应用期间由插件生成的新项追加到 Draft；JsonIgnore 的动态字段单独恢复。
+            foreach (var liveItem in live.MonitorItems)
+            {
+                if (liveItem == null || string.IsNullOrEmpty(liveItem.Key) || retainedKeys.Contains(liveItem.Key))
+                    continue;
+
+                var json = System.Text.Json.JsonSerializer.Serialize(liveItem);
+                var clonedItem = System.Text.Json.JsonSerializer.Deserialize<MonitorItemConfig>(json);
+                if (clonedItem == null) continue;
+
+                clonedItem.DynamicLabel = liveItem.DynamicLabel;
+                clonedItem.DynamicTaskbarLabel = liveItem.DynamicTaskbarLabel;
+                mergedItems.Add(clonedItem);
+                retainedKeys.Add(liveItem.Key);
+            }
+
+            draft.MonitorItems = mergedItems;
         }
-        
         /// <summary>
         /// 向设置中添加新的插件实例。
         /// </summary>

--- a/src/UI/Controls/MonitorControls.cs
+++ b/src/UI/Controls/MonitorControls.cs
@@ -359,7 +359,7 @@ namespace LiteMonitor.src.UI.Controls
                 ForeColor = Color.Gray 
             };
 
-            string defGName = LanguageManager.T("Groups." + groupKey);
+            string defGName = LanguageManager.GetOriginal(UIUtils.Intern("Groups." + groupKey));
             if (defGName.StartsWith("Groups.")) defGName = groupKey;
             
             InputAlias = new LiteUnderlineInput(string.IsNullOrEmpty(alias) ? defGName : alias, "", "", 100) 

--- a/src/UI/Helpers/LiteTooltipForm.cs
+++ b/src/UI/Helpers/LiteTooltipForm.cs
@@ -19,6 +19,7 @@ namespace LiteMonitor.src.UI.Helpers
         private const int PADDING_Y = 8;
         private const int ROW_HEIGHT = 22;
         private const int GROUP_GAP = 4;     // 组间距
+        private const int COLUMN_GAP = 8;    // 标签和值之间的最小间距
         
         // 缓存数据
         private List<GroupLayoutInfo>? _groups;
@@ -106,6 +107,31 @@ namespace LiteMonitor.src.UI.Helpers
 
         private int S(int val) => (int)(val * _scale);
 
+        private Font GetTextFont()
+        {
+            return UIUtils.GetFont(
+                _theme!.FontItem.FontFamily.Name,
+                Math.Max(8f, _theme.FontItem.Size - 0.5f),
+                _isBold);
+        }
+
+        private int GetRowHeight(Font font)
+        {
+            // 缩放较小时字体仍有最小字号，行高不能继续缩到字体实际高度以下。
+            return Math.Max(S(ROW_HEIGHT), font.Height + Math.Max(2, S(2)));
+        }
+
+        private static int MeasureTextWidth(string text, Font font)
+        {
+            if (string.IsNullOrEmpty(text)) return 0;
+
+            return TextRenderer.MeasureText(
+                text,
+                font,
+                Size.Empty,
+                TextFormatFlags.SingleLine | TextFormatFlags.NoPadding).Width;
+        }
+
         private void CalculateLayout(int fixedWidth)
         {
             if (_groups == null || _groups.Count == 0 || _theme == null)
@@ -114,13 +140,35 @@ namespace LiteMonitor.src.UI.Helpers
                 return;
             }
 
-            // 1. 使用固定宽度 (不再测量文本，极大提升性能)
-            _totalWidth = fixedWidth;
+            var smallFont = GetTextFont();
+
+            // 1. 固定宽度作为基准，但不能小于实际标签和值所需的宽度。
+            //    低缩放下字体有最小字号，单纯按比例缩小会导致两列文字重叠。
+            int paddingX = Math.Max(1, S(PADDING_X));
+            int textGap = Math.Max(4, S(COLUMN_GAP));
+            int minContentWidth = 0;
+
+            foreach (var group in _groups)
+            {
+                foreach (var item in group.Items)
+                {
+                    string label = item.Label;
+                    if (string.IsNullOrEmpty(label)) label = item.Key;
+
+                    string value = item.GetFormattedText(false);
+                    int lineWidth = MeasureTextWidth(label, smallFont)
+                        + textGap
+                        + MeasureTextWidth(value, smallFont);
+                    minContentWidth = Math.Max(minContentWidth, lineWidth);
+                }
+            }
+
+            _totalWidth = Math.Max(fixedWidth, paddingX * 2 + minContentWidth);
 
             // 2. 计算总高度
-            int paddingY = S(PADDING_Y);
-            int groupGap = S(GROUP_GAP);
-            int rowHeight = S(ROW_HEIGHT);
+            int paddingY = Math.Max(1, S(PADDING_Y));
+            int groupGap = Math.Max(1, S(GROUP_GAP));
+            int rowHeight = GetRowHeight(smallFont);
 
             // 优化：预先计算总行数，避免循环累加
             int totalLines = _groups.Sum(g => g.Items.Count);
@@ -259,7 +307,8 @@ namespace LiteMonitor.src.UI.Helpers
             using var penSep = new Pen(_separatorColor);
 
             // 优化：提前获取字体，避免在循环中重复查找 (GetFont 内部虽然有字典缓存，但仍有哈希查找开销)
-            var smallFont = UIUtils.GetFont(_theme.FontItem.FontFamily.Name, Math.Max(8f, _theme.FontItem.Size - 0.5f), _isBold);
+            var smallFont = GetTextFont();
+            rowHeight = GetRowHeight(smallFont);
 
             for (int i = 0; i < _groups.Count; i++)
             {

--- a/src/UI/Helpers/MainFormBizHelper.cs
+++ b/src/UI/Helpers/MainFormBizHelper.cs
@@ -112,14 +112,15 @@ namespace LiteMonitor.src.UI.Helpers
             if (IsDragging || _form.ContextMenuStrip?.Visible == true) return;
             if (DateTime.Now < _keepVisibleUntil) return;
 
-            var center = new Point(_form.Left + _form.Width / 2, _form.Top + _form.Height / 2);
-            var screen = Screen.FromPoint(center);
+            // 以窗口覆盖面积最大的显示器作为归属，避免窗口跨屏时仅因中心点越过边界就切换显示器。
+            var screen = Screen.FromControl(_form);
             var area = screen.WorkingArea;
             var cursor = Cursor.Position;
 
-            bool nearLeft = _form.Left <= area.Left + _hideThreshold;
-            bool nearRight = area.Right - _form.Right <= _hideThreshold;
-            bool nearTop = _form.Top <= area.Top + _hideThreshold;
+            // 内部屏幕边界不是自动隐藏边缘。例如左屏右侧连接着右屏时，不能把窗口推到右屏。
+            bool nearLeft = !HasAdjacentScreen(screen, DockEdge.Left) && _form.Left <= area.Left + _hideThreshold;
+            bool nearRight = !HasAdjacentScreen(screen, DockEdge.Right) && area.Right - _form.Right <= _hideThreshold;
+            bool nearTop = !HasAdjacentScreen(screen, DockEdge.Top) && _form.Top <= area.Top + _hideThreshold;
 
             bool shouldHide = nearLeft || nearRight || nearTop;
 
@@ -150,6 +151,34 @@ namespace LiteMonitor.src.UI.Helpers
                     else if (_dock == DockEdge.Top && cursor.Y <= area.Top + hoverBand) { _form.Top = area.Top; _isHidden = false; _dock = DockEdge.None; }
                 }
             }
+        }
+
+        private static bool HasAdjacentScreen(Screen screen, DockEdge edge)
+        {
+            const int tolerance = 1;
+            Rectangle bounds = screen.Bounds;
+
+            foreach (var other in Screen.AllScreens)
+            {
+                if (other.DeviceName == screen.DeviceName) continue;
+
+                Rectangle otherBounds = other.Bounds;
+                bool horizontalOverlap = otherBounds.Left < bounds.Right && otherBounds.Right > bounds.Left;
+                bool verticalOverlap = otherBounds.Top < bounds.Bottom && otherBounds.Bottom > bounds.Top;
+
+                bool adjacent = edge switch
+                {
+                    DockEdge.Left => otherBounds.Right >= bounds.Left - tolerance && otherBounds.Left < bounds.Left && verticalOverlap,
+                    DockEdge.Right => otherBounds.Left <= bounds.Right + tolerance && otherBounds.Right > bounds.Right && verticalOverlap,
+                    DockEdge.Top => otherBounds.Bottom >= bounds.Top - tolerance && otherBounds.Top < bounds.Top && horizontalOverlap,
+                    DockEdge.Bottom => otherBounds.Top <= bounds.Bottom + tolerance && otherBounds.Bottom > bounds.Bottom && horizontalOverlap,
+                    _ => false
+                };
+
+                if (adjacent) return true;
+            }
+
+            return false;
         }
 
         // =================================================================
@@ -226,8 +255,7 @@ namespace LiteMonitor.src.UI.Helpers
         public void SavePos()
         {
             ClampToScreen(force: false);
-            var center = new Point(_form.Left + _form.Width / 2, _form.Top + _form.Height / 2);
-            var scr = Screen.FromPoint(center);
+            var scr = Screen.FromControl(_form);
 
             _cfg.ScreenDevice = scr.DeviceName;
             _cfg.Position = new Point(_form.Left, _form.Top);

--- a/src/UI/Helpers/TaskbarTooltipHelper.cs
+++ b/src/UI/Helpers/TaskbarTooltipHelper.cs
@@ -48,6 +48,9 @@ namespace LiteMonitor.src.UI.Helpers
 
         public void ReloadMode()
         {
+            // 缩放或主题变化后，下一次显示必须按新的物理尺寸重新计算宽度。
+            _cachedTargetWidth = 0;
+
             // 清理旧的事件和计时器
             if (!_targetForm.IsDisposed)
             {

--- a/src/UI/Settings/MonitorPage.cs
+++ b/src/UI/Settings/MonitorPage.cs
@@ -207,6 +207,34 @@ namespace LiteMonitor.src.UI.SettingsPage
             _isLoaded = true;
         }
 
+        public void RefreshAfterApply()
+        {
+            if (!_isLoaded || Config == null) return;
+
+            try
+            {
+                var sourceList = Config.MonitorItems ?? new List<MonitorItemConfig>();
+                var json = JsonSerializer.Serialize(sourceList);
+                _workingList = JsonSerializer.Deserialize<List<MonitorItemConfig>>(json) ?? new List<MonitorItemConfig>();
+
+                var liveMap = sourceList.ToDictionary(x => x.Key, x => x);
+                foreach (var item in _workingList)
+                {
+                    if (liveMap.TryGetValue(item.Key, out var liveItem))
+                    {
+                        item.DynamicLabel = liveItem.DynamicLabel;
+                        item.DynamicTaskbarLabel = liveItem.DynamicTaskbarLabel;
+                    }
+                }
+            }
+            catch
+            {
+                _workingList = new List<MonitorItemConfig>();
+            }
+
+            _lastDataSignature = GenerateSignature();
+            ReloadList();
+        }
         private string GenerateSignature()
         {
             if (Config?.MonitorItems == null) return "null";
@@ -214,11 +242,25 @@ namespace LiteMonitor.src.UI.SettingsPage
             // [Fix] Include DynamicLabel in signature to detect label updates (Plugin Sync)
             var sb = new System.Text.StringBuilder();
             sb.Append(Config.MonitorItems.Count);
+            if (Config.GroupAliases != null)
+            {
+                foreach (var alias in Config.GroupAliases.OrderBy(x => x.Key, StringComparer.OrdinalIgnoreCase))
+                {
+                    sb.Append("|GROUP:");
+                    sb.Append(alias.Key);
+                    sb.Append('=');
+                    sb.Append(alias.Value ?? "");
+                }
+            }
             
             foreach (var item in Config.MonitorItems)
             {
                 sb.Append('|');
                 sb.Append(item.Key);
+                sb.Append(':');
+                sb.Append(item.SortIndex);
+                sb.Append(':');
+                sb.Append(item.TaskbarSortIndex);
                 // 动态属性
                 sb.Append(':');
                 sb.Append(item.DynamicLabel ?? ""); 
@@ -498,8 +540,8 @@ namespace LiteMonitor.src.UI.SettingsPage
                 foreach (var block in blocks)
                 {
                     string alias = block.Header.InputAlias.Inner.Text.Trim();
-                    string defName = LanguageManager.T("Groups." + block.Header.GroupKey);
-                    if (!string.IsNullOrEmpty(alias) && alias != defName) 
+                    string defName = LanguageManager.GetOriginal(UIUtils.Intern("Groups." + block.Header.GroupKey));
+                    if (!string.IsNullOrEmpty(alias) && !string.Equals(alias, defName, StringComparison.Ordinal))
                         Config.GroupAliases[block.Header.GroupKey] = alias;
                     else 
                         Config.GroupAliases.Remove(block.Header.GroupKey);

--- a/src/UI/SettingsForm.cs
+++ b/src/UI/SettingsForm.cs
@@ -248,6 +248,10 @@ namespace LiteMonitor.src.UI
             // 5. [Fix] Rebase Draft to match Live
             // 将 Live 环境中由插件生成的最新监控项同步回 Draft，并保留动态显示属性
             SettingsChanger.RebaseDraftMonitorItems(_cfg, _draftCfg);
+            if (_pages.TryGetValue("Monitor", out var monitorPage) && monitorPage is MonitorPage page)
+            {
+                page.RefreshAfterApply();
+            }
         }
     }
 }


### PR DESCRIPTION
## 变更内容

- 修复窗口贴在多屏交界处时，鼠标移动导致窗口错误自动隐藏或切换屏幕的问题。
- 修复监控设置点击“应用”后再次点击“确定”时配置回退的问题。
- 修复低界面缩放比例下，任务栏悬浮窗口文字挤压和重叠的问题。

## 验证

- 测试了窗口跨屏贴边和多屏切换。
- 测试了监控设置连续点击“应用”和“确定”。
- 测试了低缩放比例下任务栏悬浮窗口的文字布局。
- 已确认本 PR 不包含 RTSS、PresentMon、FPS 或 fork 个性化修改。

## 构建说明

代码编译目标检查通过。完整构建受到原始项目缺少
`使用说明(必读).txt` 文件的既有问题影响，与本 PR 无关。