### PR TITLE
feat(taskbar): show metrics on all monitors

### DIFF
--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -149,6 +149,7 @@
     "TaskbarHoverShowAll": "Hover-Details",
     "TaskbarStyle": "Stil",
     "TaskbarMonitor": "Bildschirm",
+    "AllMonitors": "Alle Bildschirme",
     "TaskbarStyleBold": "Groß",
     "TaskbarStyleRegular": "Klein",
     "TaskbarAlign": "Position",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -149,6 +149,7 @@
     "TaskbarHoverShowAll": "Hover Details",
     "TaskbarStyle": "Style",
     "TaskbarMonitor": "Monitor",
+    "AllMonitors": "All monitors",
     "TaskbarStyleBold": "Big",
     "TaskbarStyleRegular": "Small",
     "TaskbarAlign": "Position",

--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -149,6 +149,7 @@
     "TaskbarHoverShowAll": "Detalles al pasar",
     "TaskbarStyle": "Estilo",
     "TaskbarMonitor": "Pantalla",
+    "AllMonitors": "Todos los monitores",
     "TaskbarStyleBold": "Grande",
     "TaskbarStyleRegular": "Pequeño",
     "TaskbarAlign": "Posición",

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -150,6 +150,7 @@
     "TaskbarHoverShowAll": "Détails au survol",
     "TaskbarStyle": "Style",
     "TaskbarMonitor": "Écran",
+    "AllMonitors": "Tous les écrans",
     "TaskbarStyleBold": "Grand",
     "TaskbarStyleRegular": "Petit",
     "TaskbarAlign": "Position",

--- a/resources/lang/ja.json
+++ b/resources/lang/ja.json
@@ -150,6 +150,7 @@
     "TaskbarHoverShowAll": "ホバーで詳細表示",
     "TaskbarStyle": "スタイル",
     "TaskbarMonitor": "モニター",
+    "AllMonitors": "すべてのモニター",
     "TaskbarStyleBold": "大文字",
     "TaskbarStyleRegular": "小文字",
     "TaskbarAlign": "表示位置",

--- a/resources/lang/ko.json
+++ b/resources/lang/ko.json
@@ -149,6 +149,7 @@
     "TaskbarHoverShowAll": "마우스 오버 상세",
     "TaskbarStyle": "스타일",
     "TaskbarMonitor": "모니터",
+    "AllMonitors": "모든 모니터",
     "TaskbarStyleBold": "큰 글자",
     "TaskbarStyleRegular": "작은 글자",
     "TaskbarAlign": "위치",

--- a/resources/lang/ru.json
+++ b/resources/lang/ru.json
@@ -149,6 +149,7 @@
     "TaskbarHoverShowAll": "Детали при наведении",
     "TaskbarStyle": "Стиль",
     "TaskbarMonitor": "Экран",
+    "AllMonitors": "Все мониторы",
     "TaskbarStyleBold": "Крупно",
     "TaskbarStyleRegular": "Мелко",
     "TaskbarAlign": "Позиция",

--- a/resources/lang/zh-tw.json
+++ b/resources/lang/zh-tw.json
@@ -146,6 +146,7 @@
     "TaskbarHoverShowAll": "滑鼠懸停顯示詳情",
     "TaskbarStyle": "工作列樣式",
     "TaskbarMonitor": "顯示器螢幕",
+    "AllMonitors": "所有螢幕",
     "TaskbarStyleBold": "大字模式",
     "TaskbarStyleRegular": "小字模式",
     "TaskbarAlign": "顯示位置",

--- a/resources/lang/zh.json
+++ b/resources/lang/zh.json
@@ -149,6 +149,7 @@
     "TaskbarHoverShowAll": "鼠标悬停显示详情",
     "TaskbarStyle": "任务栏样式",
     "TaskbarMonitor": "显示器屏幕",
+    "AllMonitors": "所有屏幕",
     "TaskbarStyleBold": "大字模式",
     "TaskbarStyleRegular": "小字模式",
     "TaskbarAlign": "显示位置",

--- a/src/Core/Settings.cs
+++ b/src/Core/Settings.cs
@@ -86,6 +86,9 @@ namespace LiteMonitor
         
         // ★★★ 新增：指定任务栏显示的屏幕设备名 ("" = 自动/主屏) ★★★
         public string TaskbarMonitorDevice { get; set; } = "";
+        // 在每个具有系统任务栏的显示器上镜像同一组监控数据。
+        // 独立布尔值可保留旧用户最后选择的单屏设备，关闭后能直接恢复。
+        public bool TaskbarShowOnAllMonitors { get; set; } = false;
 
         // 任务栏行为配置
         public bool TaskbarClickThrough { get; set; } = false;     // 鼠标穿透

--- a/src/UI/Helpers/TaskbarBizHelper.cs
+++ b/src/UI/Helpers/TaskbarBizHelper.cs
@@ -16,6 +16,8 @@ namespace LiteMonitor.src.UI.Helpers
         private readonly Form _form;
         private readonly Settings _cfg;
         private readonly TaskbarWinHelper _winHelper;
+        private readonly string _targetDevice;
+        private readonly bool _fallbackToPrimary;
         
         private Rectangle _taskbarRect = Rectangle.Empty;
         private int _taskbarHeight = 32;
@@ -33,11 +35,18 @@ namespace LiteMonitor.src.UI.Helpers
         public Color TransparentKey => _transparentKey;
         public bool LastIsLightTheme => _lastIsLightTheme;
 
-        public TaskbarBizHelper(Form form, Settings cfg, TaskbarWinHelper winHelper)
+        public TaskbarBizHelper(
+            Form form,
+            Settings cfg,
+            TaskbarWinHelper winHelper,
+            string targetDevice,
+            bool fallbackToPrimary)
         {
             _form = form;
             _cfg = cfg;
             _winHelper = winHelper;
+            _targetDevice = targetDevice ?? string.Empty;
+            _fallbackToPrimary = fallbackToPrimary;
             _isWin11 = Environment.OSVersion.Version >= new Version(10, 0, 22000);
         }
 
@@ -84,7 +93,7 @@ namespace LiteMonitor.src.UI.Helpers
         // =================================================================
         public void FindHandles()
         {
-            var handles = _winHelper.FindHandles(_cfg.TaskbarMonitorDevice);
+            var handles = _winHelper.FindHandles(_targetDevice, _fallbackToPrimary);
             _hTaskbar = handles.hTaskbar;
             _hTray = handles.hTray;
         }
@@ -104,7 +113,7 @@ namespace LiteMonitor.src.UI.Helpers
 
         public void UpdateTaskbarRect()
         {
-            _taskbarRect = _winHelper.GetTaskbarRect(_hTaskbar, _cfg.TaskbarMonitorDevice);
+            _taskbarRect = _winHelper.GetTaskbarRect(_hTaskbar, _targetDevice);
             _taskbarHeight = Math.Max(24, _taskbarRect.Height);
         }
 

--- a/src/UI/Helpers/TaskbarWinHelper.cs
+++ b/src/UI/Helpers/TaskbarWinHelper.cs
@@ -184,13 +184,20 @@ namespace LiteMonitor.src.UI.Helpers
         // =================================================================
         // 句柄与信息获取 (通用逻辑)
         // =================================================================
-        public (IntPtr hTaskbar, IntPtr hTray) FindHandles(string targetDevice)
+        public (IntPtr hTaskbar, IntPtr hTray) FindHandles(string targetDevice, bool fallbackToPrimary = true)
         {
-            Screen target = Screen.PrimaryScreen;
+            Screen? target = Screen.PrimaryScreen;
             if (!string.IsNullOrEmpty(targetDevice))
             {
-                target = Screen.AllScreens.FirstOrDefault(s => s.DeviceName == targetDevice) ?? Screen.PrimaryScreen;
+                target = Screen.AllScreens.FirstOrDefault(s => s.DeviceName == targetDevice);
+                if (target == null)
+                {
+                    if (!fallbackToPrimary) return (IntPtr.Zero, IntPtr.Zero);
+                    target = Screen.PrimaryScreen;
+                }
             }
+
+            if (target == null) return (IntPtr.Zero, IntPtr.Zero);
 
             if (target.Primary)
             {
@@ -200,12 +207,12 @@ namespace LiteMonitor.src.UI.Helpers
             }
             else
             {
-                IntPtr hTaskbar = FindSecondaryTaskbar(target);
+                IntPtr hTaskbar = FindSecondaryTaskbar(target, fallbackToPrimary);
                 return (hTaskbar, IntPtr.Zero);
             }
         }
 
-        private IntPtr FindSecondaryTaskbar(Screen screen)
+        private IntPtr FindSecondaryTaskbar(Screen screen, bool fallbackToPrimary)
         {
             IntPtr hWnd = IntPtr.Zero;
             while ((hWnd = FindWindowEx(IntPtr.Zero, hWnd, "Shell_SecondaryTrayWnd", null)) != IntPtr.Zero)
@@ -215,7 +222,7 @@ namespace LiteMonitor.src.UI.Helpers
                 if (screen.Bounds.Contains(r.Location) || screen.Bounds.IntersectsWith(r))
                     return hWnd;
             }
-            return FindWindow("Shell_TrayWnd", null);
+            return fallbackToPrimary ? FindWindow("Shell_TrayWnd", null) : IntPtr.Zero;
         }
 
         public Rectangle GetTaskbarRect(IntPtr hTaskbar, string targetDevice)

--- a/src/UI/MainForm_Transparent.cs
+++ b/src/UI/MainForm_Transparent.cs
@@ -3,6 +3,7 @@ using LiteMonitor.src.SystemServices;
 using LiteMonitor.src.UI;
 using LiteMonitor.src.UI.Helpers;
 using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
@@ -72,47 +73,90 @@ namespace LiteMonitor
         public void CleanMemory() => _bizHelper.CleanMemory();
 
         // ==== 任务栏显示 ====
-        private TaskbarForm? _taskbar;
+        private readonly Dictionary<string, TaskbarForm> _taskbars =
+            new(StringComparer.OrdinalIgnoreCase);
+        private bool _taskbarAllMonitorsMode;
 
         public void ToggleTaskbar(bool show)
         {
-            if (show)
+            if (!show)
             {
-                if (_taskbar != null && !_taskbar.IsDisposed)
-                {
-                    if (_taskbar.TargetDevice != _cfg.TaskbarMonitorDevice)
-                    {
-                        _taskbar.Close();
-                        _taskbar.Dispose();
-                        _taskbar = null;
-                    }
-                }
+                CloseAllTaskbarForms();
+                return;
+            }
 
-                if (_taskbar == null || _taskbar.IsDisposed)
+            if (_ui == null) return;
+
+            bool allMonitors = _cfg.TaskbarShowOnAllMonitors;
+            if (_taskbars.Count > 0 && _taskbarAllMonitorsMode != allMonitors)
+            {
+                CloseAllTaskbarForms();
+            }
+            _taskbarAllMonitorsMode = allMonitors;
+
+            var desiredDevices = GetDesiredTaskbarDevices();
+            var desiredSet = new HashSet<string>(desiredDevices, StringComparer.OrdinalIgnoreCase);
+
+            foreach (string existing in _taskbars.Keys.ToList())
+            {
+                if (!desiredSet.Contains(existing) || _taskbars[existing].IsDisposed)
                 {
-                    if (_ui != null)
-                    {
-                        _taskbar = new TaskbarForm(_cfg, _ui, this);
-                        _taskbar.Show();
-                    }
-                }
-                else
-                {
-                    if (!_taskbar.Visible)
-                    {
-                        _taskbar.Show();
-                        _taskbar.ReloadLayout();
-                    }
+                    CloseTaskbarForm(existing);
                 }
             }
-            else
+
+            foreach (string device in desiredDevices)
             {
-                if (_taskbar != null)
+                if (!_taskbars.TryGetValue(device, out TaskbarForm? taskbar) || taskbar.IsDisposed)
                 {
-                    _taskbar.Close();
-                    _taskbar.Dispose();
-                    _taskbar = null;
+                    taskbar = new TaskbarForm(
+                        _cfg,
+                        _ui,
+                        this,
+                        device,
+                        fallbackToPrimary: !allMonitors);
+                    _taskbars[device] = taskbar;
                 }
+
+                if (!taskbar.Visible) taskbar.ReloadLayout();
+                taskbar.ShowWhenReady();
+            }
+        }
+
+        private List<string> GetDesiredTaskbarDevices()
+        {
+            if (_cfg.TaskbarShowOnAllMonitors)
+            {
+                return Screen.AllScreens
+                    .OrderByDescending(screen => screen.Primary)
+                    .Select(screen => screen.DeviceName)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+            }
+
+            return new List<string> { _cfg.TaskbarMonitorDevice ?? string.Empty };
+        }
+
+        private void CloseTaskbarForm(string device)
+        {
+            if (!_taskbars.Remove(device, out TaskbarForm? taskbar)) return;
+
+            try
+            {
+                if (!taskbar.IsDisposed)
+                {
+                    taskbar.Close();
+                    taskbar.Dispose();
+                }
+            }
+            catch { }
+        }
+
+        private void CloseAllTaskbarForms()
+        {
+            foreach (string device in _taskbars.Keys.ToList())
+            {
+                CloseTaskbarForm(device);
             }
         }
 
@@ -270,7 +314,11 @@ namespace LiteMonitor
                 {
                     if (!t.IsCanceled)
                     {
-                        this.BeginInvoke(new Action(() => _bizHelper?.RestorePos()));
+                        this.BeginInvoke(new Action(() =>
+                        {
+                            _bizHelper?.RestorePos();
+                            if (_cfg.ShowTaskbar) ToggleTaskbar(true);
+                        }));
                     }
                 });
             }
@@ -346,6 +394,7 @@ namespace LiteMonitor
 
         protected override void OnFormClosed(FormClosedEventArgs e)
         {
+            CloseAllTaskbarForms();
             _cfg.Save(); 
             TrafficLogger.Save(); 
             HardwareHistoryLogger.Save();

--- a/src/UI/Settings/TaskbarPage.cs
+++ b/src/UI/Settings/TaskbarPage.cs
@@ -121,18 +121,32 @@ namespace LiteMonitor.src.UI.SettingsPage
             // Monitor Selection
             var screens = Screen.AllScreens;
             var screenNames = screens.Select((s, i) => $"{i + 1}: {s.DeviceName.Replace(@"\\.\DISPLAY", "Display ")}{(s.Primary ? " [Main]" : "")}").ToList();
+            screenNames.Insert(0, LanguageManager.T("Menu.AllMonitors"));
             screenNames.Insert(0, LanguageManager.T("Menu.Auto"));
             
             group.AddComboIndex(this, "Menu.TaskbarMonitor", screenNames.ToArray(), 
                 () => {
+                    if (Config?.TaskbarShowOnAllMonitors == true) return 1;
                     if (string.IsNullOrEmpty(Config?.TaskbarMonitorDevice)) return 0;
                     var idx = Array.FindIndex(screens, s => s.DeviceName == Config.TaskbarMonitorDevice);
-                    return idx >= 0 ? idx + 1 : 0;
+                    return idx >= 0 ? idx + 2 : 0;
                 },
                 idx => {
                     if (Config == null) return;
-                    if (idx == 0) Config.TaskbarMonitorDevice = ""; 
-                    else Config.TaskbarMonitorDevice = screens[idx - 1].DeviceName;
+                    if (idx == 0)
+                    {
+                        Config.TaskbarShowOnAllMonitors = false;
+                        Config.TaskbarMonitorDevice = "";
+                    }
+                    else if (idx == 1)
+                    {
+                        Config.TaskbarShowOnAllMonitors = true;
+                    }
+                    else
+                    {
+                        Config.TaskbarShowOnAllMonitors = false;
+                        Config.TaskbarMonitorDevice = screens[idx - 2].DeviceName;
+                    }
                 }
             );
 

--- a/src/UI/TaskbarForm.cs
+++ b/src/UI/TaskbarForm.cs
@@ -21,6 +21,7 @@ namespace LiteMonitor
         
         private HorizontalLayout _layout;
         private List<Column>? _cols;
+        private List<Column>? _sourceCols;
         private ContextMenuStrip? _currentMenu;
         private DateTime _lastFindHandleTime = DateTime.MinValue;
         private string _lastLayoutSignature = "";
@@ -37,18 +38,28 @@ namespace LiteMonitor
         private const int WM_LBUTTONDBLCLK = 0x0203;
         private bool _isWin11;
 
-        public TaskbarForm(Settings cfg, UIController ui, MainForm mainForm)
+        public TaskbarForm(
+            Settings cfg,
+            UIController ui,
+            MainForm mainForm,
+            string? targetDevice = null,
+            bool fallbackToPrimary = true)
         {
             _cfg = cfg;
             _ui = ui;
             _mainForm = mainForm;
-            TargetDevice = _cfg.TaskbarMonitorDevice;
+            TargetDevice = targetDevice ?? _cfg.TaskbarMonitorDevice;
 
             _isWin11 = Environment.OSVersion.Version >= new Version(10, 0, 22000);
 
             // 初始化组件
             _winHelper = new TaskbarWinHelper(this);
-            _bizHelper = new TaskbarBizHelper(this, _cfg, _winHelper);
+            _bizHelper = new TaskbarBizHelper(
+                this,
+                _cfg,
+                _winHelper,
+                TargetDevice,
+                fallbackToPrimary);
 
             // 窗体属性
             FormBorderStyle = FormBorderStyle.None;
@@ -73,6 +84,25 @@ namespace LiteMonitor
             _tooltipHelper = new TaskbarTooltipHelper(this, _cfg, _ui);
 
             Tick();
+        }
+
+        public bool ShowWhenReady()
+        {
+            if (IsDisposed) return false;
+
+            if (!_bizHelper.IsTaskbarValid())
+            {
+                _bizHelper.FindHandles();
+                if (!_bizHelper.IsTaskbarValid())
+                {
+                    if (Visible) Hide();
+                    return false;
+                }
+                _bizHelper.AttachToTaskbar();
+            }
+
+            if (!Visible) Show();
+            return true;
         }
 
         public void ReloadLayout()
@@ -180,6 +210,20 @@ namespace LiteMonitor
             {
                 _bizHelper.FindHandles();
                 _lastFindHandleTime = DateTime.Now;
+
+                if (_bizHelper.IsTaskbarValid())
+                {
+                    _bizHelper.AttachToTaskbar();
+                    if (!Visible) Show();
+                }
+            }
+
+            // “所有屏幕”模式下，系统可能没有为某块屏幕创建副任务栏。
+            // 此时保持窗体隐藏，避免它回退到主任务栏或漂浮在桌面上。
+            if (!_bizHelper.IsTaskbarValid())
+            {
+                if (Visible) Hide();
+                return;
             }
 
             if (Math.Abs(Environment.TickCount) % 5000 < _cfg.RefreshMs) _bizHelper.CheckTheme();
@@ -190,7 +234,14 @@ namespace LiteMonitor
             var nextCols = _ui.GetTaskbarColumns();
             if (nextCols == null || nextCols.Count == 0) return;
             
-            _cols = nextCols; // 确认有效后再更新引用
+            // 每个任务栏窗体必须拥有独立的 Bounds/ColumnWidth。
+            // MetricItem 仍共享，因此硬件数据只采集一次；不同 DPI 不会互相覆盖布局。
+            if (!ReferenceEquals(_sourceCols, nextCols) || _cols == null)
+            {
+                _sourceCols = nextCols;
+                _cols = CloneColumns(nextCols);
+                _lastLayoutSignature = "";
+            }
 
             _bizHelper.UpdateTaskbarRect(); 
             
@@ -227,6 +278,26 @@ namespace LiteMonitor
             _tooltipHelper.UpdateContent();
 
             Invalidate();
+        }
+
+        private static List<Column> CloneColumns(List<Column> source)
+        {
+            var result = new List<Column>(source.Count);
+            foreach (Column column in source)
+            {
+                result.Add(new Column
+                {
+                    Top = column.Top,
+                    Bottom = column.Bottom
+                });
+            }
+            return result;
+        }
+
+        protected override void OnDpiChanged(DpiChangedEventArgs e)
+        {
+            base.OnDpiChanged(e);
+            ReloadLayout();
         }
 
         protected override void OnPaintBackground(PaintEventArgs e)


### PR DESCRIPTION
## 变更内容

- 在“任务栏设置 → 显示器屏幕”中新增“所有屏幕”选项，同时保留原有自动/单屏选择。
- 单个 LiteMonitor 进程会为每个可用系统任务栏创建独立 TaskbarForm，避免多开程序带来的自启动和重叠问题。
- 每个任务栏窗口精确绑定目标显示器；副屏没有系统任务栏时保持隐藏，不回退并重复显示到主屏。
- 各窗口共享同一组监控数据，但隔离布局坐标和宽度，避免不同 DPI 屏幕相互覆盖布局状态。
- 显示拓扑变化后重新同步窗口，并为所有内置语言补充 AllMonitors 文案。

## 兼容性

- TaskbarShowOnAllMonitors 默认为 false，现有用户仍保持原来的单屏行为。
- 最后选择的单屏设备会被保留，关闭“所有屏幕”后可以直接恢复。
- 本分支直接基于 upstream master，不包含 #555 的任务栏自恢复改动。

## 验证

- .NET 8 Release 构建：0 errors。
- 9 个内置语言 JSON 均可解析，且 Menu.AllMonitors 均能解析到非空本地化文本。
- Windows 11 双屏实测：检测到两个可见的 LiteMonitor 子窗口，分别挂载到 Shell_TrayWnd 与 Shell_SecondaryTrayWnd，未生成 LiteMonitor_Error.log。
- 功能构建已由实际双屏用户持续使用并确认工作正常。

## 尚未人工覆盖

- Windows 10。
- 三屏及以上环境。
- 实际热插拔过程（代码会在 WM_DISPLAYCHANGE 后重新同步显示器集合）。

Closes #169